### PR TITLE
Fix recording folder hierarchy

### DIFF
--- a/getting-started/capture-workflow.md
+++ b/getting-started/capture-workflow.md
@@ -76,11 +76,11 @@ You can make as many recordings as you like.
 The default `recordings` directory will have the following hierarchy.
 
 * `recordings`
-  * 2016-04-05
-    * 001
-    * 002
-    * 003
-    * ####
+	* 2016-04-05
+		* 001
+		* 002
+		* 003
+		* ####
 
 #### How recordings are saved?
 


### PR DESCRIPTION
This is a markdown render issue. This uses Blackfriday Markdown which is different to what Github uses. Using tabs of 4 spaces renders the nested level correctly.

