### PR TITLE
Update Linux install instructions.

### DIFF
--- a/developer-docs/linux.md
+++ b/developer-docs/linux.md
@@ -44,8 +44,8 @@ sudo ldconfig
 ```
 
 <aside class="notice">
-OpenCv is not able to build Python 2 and Python 3 modules at the same time.
-OpenCv will build the Python 2 module by default if requirements for both
+OpenCV is not able to build Python 2 and Python 3 modules at the same time.
+OpenCV will build the Python 2 module by default if requirements for both
 versions are met. Setting the Python 2 Numpy include directory to an empty
 string effectively disables the Python 2 module build.
 </aside>

--- a/developer-docs/linux.md
+++ b/developer-docs/linux.md
@@ -43,6 +43,13 @@ sudo make install
 sudo ldconfig
 ```
 
+<aside class="notice">
+Opencv is not able to build Python 2 and Python 3 modules at the same time.
+Opencv will build the Python 2 module by default iff requirements for both
+versions are met. Setting the Python 2 Numpy include directory to an empty
+string disables effectively the Python 2 module build.
+</aside>
+
 <aside class="faq">
 Do *not* install `opencv-python` via pip if you see `ImportError: No module named 'cv2'`.
 The error appears if the above requisites were not met.

--- a/developer-docs/linux.md
+++ b/developer-docs/linux.md
@@ -44,10 +44,10 @@ sudo ldconfig
 ```
 
 <aside class="notice">
-Opencv is not able to build Python 2 and Python 3 modules at the same time.
-Opencv will build the Python 2 module by default iff requirements for both
+OpenCv is not able to build Python 2 and Python 3 modules at the same time.
+OpenCv will build the Python 2 module by default if requirements for both
 versions are met. Setting the Python 2 Numpy include directory to an empty
-string disables effectively the Python 2 module build.
+string effectively disables the Python 2 module build.
 </aside>
 
 <aside class="faq">

--- a/developer-docs/linux.md
+++ b/developer-docs/linux.md
@@ -37,7 +37,7 @@ git clone https://github.com/opencv/opencv
 cd opencv
 mkdir build
 cd build
-cmake -D CMAKE_BUILD_TYPE=RELEASE -D BUILD_TBB=ON -D WITH_TBB=ON ..
+cmake -D CMAKE_BUILD_TYPE=RELEASE -D BUILD_TBB=ON -D WITH_TBB=ON -D WITH_CUDA=OFF -D PYTHON2_NUMPY_INCLUDE_DIRS='' ..
 make -j2
 sudo make install
 sudo ldconfig


### PR DESCRIPTION
Opencv is not able to build Python 2 and Python 3 modules at the same time. If requirements for both versions is met Opencv will build the Python 2 module.

This PR sets the Python 2 Numpy include directory to `<empty string>`, effectively disabling the Python 2 module build.