### PR TITLE
Dev docs: Update macOS install instruct. to install boost-python3

### DIFF
--- a/developer-docs/macos.md
+++ b/developer-docs/macos.md
@@ -56,7 +56,7 @@ brew tap homebrew/versions
 brew install glfw3
 # dependencies for 2d_3d c++ detector
 brew install boost
-brew install boost-python --with-python3
+brew install boost-python3
 brew install ceres-solver
 ```
 


### PR DESCRIPTION
Fixes #183 