### PR TITLE
Update windows.md

### DIFF
--- a/developer-docs/windows.md
+++ b/developer-docs/windows.md
@@ -94,7 +94,7 @@ Open your command prompt and `Run as administrator` in the directory where the w
 ### Python Libs
 Open your command prompt and install the following libs:
 
-- `pip install msgpack_python`
+- `pip install msgpack`
 - `pip install win_inet_pton`
 - `pip install git+https://github.com/zeromq/pyre.git`
 


### PR DESCRIPTION
`pip install msgpack_python` is deprecated according to the 'https://pypi.python.org/pypi/msgpack-python' on the official python page. 
Need to use `pip install msgpack` instead.