### PR TITLE
Change msgpack install cmd for linux/macos

### DIFF
--- a/developer-docs/linux.md
+++ b/developer-docs/linux.md
@@ -111,7 +111,7 @@ sudo pip3 install numexpr
 sudo pip3 install cython
 sudo pip3 install psutil
 sudo pip3 install pyzmq
-sudo pip3 install msgpack_python
+sudo pip3 install msgpack
 sudo pip3 install pyopengl
 sudo pip3 install pyaudio
 sudo pip3 install git+https://github.com/zeromq/pyre

--- a/developer-docs/macos.md
+++ b/developer-docs/macos.md
@@ -78,7 +78,7 @@ pip3 install pyzmq
 pip3 install numexpr
 pip3 install cython
 pip3 install psutil
-pip3 install msgpack_python
+pip3 install msgpack
 pip3 install pyaudio
 pip3 install git+https://github.com/zeromq/pyre
 pip3 install git+https://github.com/pupil-labs/PyAV


### PR DESCRIPTION
The PyPI name changed according to https://github.com/msgpack/msgpack-python#pypi-package-name