### PR TITLE
add pytorch installation instructions for mac

### DIFF
--- a/developer-docs/macos.md
+++ b/developer-docs/macos.md
@@ -81,6 +81,7 @@ pip3 install psutil
 pip3 install msgpack
 pip3 install pyaudio
 pip3 install cysignals
+pip3 install torch torchvision
 pip3 install git+https://github.com/zeromq/pyre
 pip3 install git+https://github.com/pupil-labs/PyAV
 pip3 install git+https://github.com/pupil-labs/pyuvc


### PR DESCRIPTION
The "macOS dependencies" part of the developer docs fails to mention to install PyTorch.

Because the macOS binaries of PyTorch don't support CUDA, you'd have to build PyTorch from source to use CUDA. Sadly I don't know how that works and the PyTorch website fails to mention how to do it, I simply left the CUDA stuff out.