### PR TITLE
Remove bad character and end of command

### DIFF
--- a/developer-docs/linux.md
+++ b/developer-docs/linux.md
@@ -29,7 +29,7 @@ sudo apt install -y libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev
 > install OpenCV >= 3.
 
 ```
-sudo apt install -y python3-opencv libopencv-dev`
+sudo apt install -y python3-opencv libopencv-dev
 ```
 
 #### Ubuntu 17.10 or lower


### PR DESCRIPTION
There was an erroneous character at the end of the command which prevented the command from executing correctly when simply copying it into terminal.