### PR TITLE
Fix fixation detector docs

### DIFF
--- a/src/core/software/pupil-capture.md
+++ b/src/core/software/pupil-capture.md
@@ -269,9 +269,9 @@ Pupil Capture or Pupil Player plugin list. Copy the plugin to the plugins folder
 within the `pupil_capture_settings` or `pupil_player_settings` folder.
 
 ### Fixation Detector
-The online fixation detector classifies fixations based on the [dispersion-duration principle](#fixation-detector). Fixations are used by the [screen and manual marker calibrations](#calibration-methods) to speed up the procedure. A fixation is visualized as a yellow circle around the gaze point that is shown in the Pupil Capture `world` window.
+The online fixation detector classifies fixations based on the dispersion-duration principle. A fixation is visualized as a yellow circle around the gaze point that is shown in the Pupil Capture `world` window.
 
-You can find more information in our [dedicated fixation detector section](#fixation-detector).
+You can find more information in our [dedicated fixation detection section](core/terminology/#fixations).
 
 ### Network plugins
 Pupil Capture has a built-in data broadcast functionality. It is based on the network library [ZeroMQ](http://zeromq.org/)

--- a/src/core/software/pupil-capture.md
+++ b/src/core/software/pupil-capture.md
@@ -271,7 +271,7 @@ within the `pupil_capture_settings` or `pupil_player_settings` folder.
 ### Fixation Detector
 The online fixation detector classifies fixations based on the dispersion-duration principle. A fixation is visualized as a yellow circle around the gaze point that is shown in the Pupil Capture `world` window.
 
-You can find more information in our [dedicated fixation detection section](core/terminology/#fixations).
+You can find more information in our [dedicated fixation detection section](/core/terminology/#fixations "Pupil Core terminology - fixations").
 
 ### Network plugins
 Pupil Capture has a built-in data broadcast functionality. It is based on the network library [ZeroMQ](http://zeromq.org/)

--- a/src/core/software/pupil-player.md
+++ b/src/core/software/pupil-player.md
@@ -198,7 +198,7 @@ This name is augmented by an automatically generated numerical identifier.
 
 
 #### Fixation Detector
-The offline fixation detector calculates fixations for the whole recording. The menu gives feedback about the progress of the detection, how many fixations were found and shows detailed information about the current fixation. Press `f` or click the `f` hot key button on the left hand side of the window to seek forward to the next fixation.
+The offline fixation detector calculates fixations for the whole recording. The menu gives feedback about the progress of the detection, how many fixations were found, and shows detailed information about the current fixation. Press `f` or click the `f` hot key button on the left hand side of the window to seek forward to the next fixation.
 
 <div class="pb-4">
   <img src="../../media/core/imgs/pg-fixation.jpg" style="display:flex;margin:0 auto;">
@@ -206,7 +206,7 @@ The offline fixation detector calculates fixations for the whole recording. The 
 
 Toggle `Show fixations` to show a visualization of fixations. The blue number is the number of the fixation (0 being the first fixation). You can export fixation reports for your current trim section by pressing `e` on your keyboard or the `e` hot key button on the left hand side of the window.
 
-You can find more information in our [dedicated fixation detection section](core/terminology/#fixations).
+You can find more information in our [dedicated fixation detection section](/core/terminology/#fixations "Pupil Core terminology - fixations").
 
 #### Head Pose Tracking
 This plugin uses fiducial markers ([apriltag](https://april.eecs.umich.edu/software/apriltag.html)) to build a 3d model of the environment and track the headset's pose within it.

--- a/src/core/software/pupil-player.md
+++ b/src/core/software/pupil-player.md
@@ -198,7 +198,7 @@ This name is augmented by an automatically generated numerical identifier.
 
 
 #### Fixation Detector
-The offline fixation detector calculates fixations for the whole recording. The menu gives feedback about the progress of the detection, how many fixations were found, shows and detailed information about the current fixation. Press `f` or click the `f` hot key button on the left hand side of the window to seek forward to the next fixation.
+The offline fixation detector calculates fixations for the whole recording. The menu gives feedback about the progress of the detection, how many fixations were found and shows detailed information about the current fixation. Press `f` or click the `f` hot key button on the left hand side of the window to seek forward to the next fixation.
 
 <div class="pb-4">
   <img src="../../media/core/imgs/pg-fixation.jpg" style="display:flex;margin:0 auto;">

--- a/src/core/software/pupil-player.md
+++ b/src/core/software/pupil-player.md
@@ -206,7 +206,7 @@ The offline fixation detector calculates fixations for the whole recording. The 
 
 Toggle `Show fixations` to show a visualization of fixations. The blue number is the number of the fixation (0 being the first fixation). You can export fixation reports for your current trim section by pressing `e` on your keyboard or the `e` hot key button on the left hand side of the window.
 
-You can find more information in our [dedicated fixation detector section](/core/software/pupil-capture/#fixation-detector).
+You can find more information in our [dedicated fixation detection section](core/terminology/#fixations).
 
 #### Head Pose Tracking
 This plugin uses fiducial markers ([apriltag](https://april.eecs.umich.edu/software/apriltag.html)) to build a 3d model of the environment and track the headset's pose within it.

--- a/src/core/software/pupil-player.md
+++ b/src/core/software/pupil-player.md
@@ -432,8 +432,8 @@ Fixations are exported to `fixations.csv`, containing the following fields:
 
 * `start_timestamp` - Timestamp of the first related gaze datum
 * `duration` - Exact fixation duration, in milliseconds
-* `start_frame_index` - Index of the first related frame
-* `end_frame_index` - Index of the last related frame
+* `start_frame_index` - Index of the first related world frame
+* `end_frame_index` - Index of the last related world frame
 * `norm_pos_x` - Normalized x position of the fixation’s centroid
 * `norm_pos_y` - Normalized y position of the fixation’s centroid
 * `dispersion` - Dispersion, in degrees

--- a/src/core/software/pupil-player.md
+++ b/src/core/software/pupil-player.md
@@ -425,3 +425,21 @@ Their values will be converted to strings using Python's string representation. 
 it is recommended to use primitive types (strings, integers, floats) as value types for
 custom fields.
 :::
+
+### Fixation Export
+
+Fixations are exported to `fixations.csv`, containing the following fields:
+
+* `start_timestamp` - Timestamp of the first related gaze datum
+* `duration` - Exact fixation duration, in milliseconds
+* `start_frame_index` - Index of the first related frame
+* `end_frame_index` - Index of the last related frame
+* `norm_pos_x` - Normalized x position of the fixation’s centroid
+* `norm_pos_y` - Normalized y position of the fixation’s centroid
+* `dispersion` - Dispersion, in degrees
+* `confidence` - Average pupil confidence
+* `method` - `2d gaze` or `3d gaze`
+* `gaze_point_3d_x` - x position of mean 3d gaze point, only available if `gaze 3d` method was used
+* `gaze_point_3d_y` - y position of mean 3d gaze point, only available if `gaze 3d` method was used
+* `gaze_point_3d_z` - z position of mean 3d gaze point, only available if `gaze 3d` method was used
+* `base_data` - Gaze data that the fixation is based on

--- a/src/core/terminology.md
+++ b/src/core/terminology.md
@@ -128,3 +128,29 @@ The Pupil Core software provides default camera intrinsics for all official Pupi
 cameras. It is recommended to run the [Camera Intrinsics Estimation](/core/software/pupil-capture/#camera-intrinsics-estimation)
 for your Pupil Core _world_ camera after receiving it. Each camera is slightly different
 and running the estimation locally will result in slightly more precise gaze mapping.
+
+## Fixations
+
+Salvucci and Goldberg define different categories of fixation detectors. One of them describes dispersion-based algorithms:
+
+> I-DT identifies fixations as groups of consecutive points within a particular dispersion, or maximum separation. Because fixations typically have a duration of at least 100 ms, dispersion-based identification techniques often incorporate a minimum duration threshold of 100-200 ms to help alleviate equipment variability.
+> 
+> *--- Salvucci, D. D., & Goldberg, J. H. (2000, November). Identifying fixations and saccades in eye-tracking protocols. In Proceedings of the 2000 symposium on Eye tracking research & applications (pp. 71-78). ACM.*
+
+Pupil’s fixation detectors implement such dispersion-based algorithms. The exact procdure differs depending on whether fixations are detected in an online or offline context:
+
+### Online Fixation Detection
+
+In Pupil Capture, fixations are detected based on a dispersion threshold in terms of degrees of visual angle with a minimum duration. Fixation are published as soon as they comply with the constraints (dispersion and duration). This might result in a series of overlapping fixations.
+
+- **Maximum Dispersion (spatial, degree):** Maximum distance between all gaze locations during a fixation.
+- **Minimum Duration (temporal, milliseconds):** The minimum duration in which the dispersion threshold must not be exceeded.
+- **Confidence Threshold:** Data with a lower confidence than this threshold is not considered during fixation detection.
+
+### Offline Fixation Detection
+
+In Pupil Player, fixations are detected based on a dispersion threshold in terms of degrees of visual angle within a given duration window. The length of classified fixations are maximized within the duration window, e.g. instead of creating two consecutive fixations of length 300 ms it creates a single fixation with length 600 ms. Fixations do not overlap.
+
+- **Maximum Dispersion (spatial, degree):** Maximum distance between all gaze locations during a fixation.
+- **Minimum Duration (temporal, milliseconds):** The minimum duration in which the dispersion threshold must not be exceeded.
+- **Maximum Duration (temporal, milliseconds):** The maximum duration in which the dispersion threshold must not be exceeded.

--- a/src/core/terminology.md
+++ b/src/core/terminology.md
@@ -137,11 +137,11 @@ Salvucci and Goldberg define different categories of fixation detectors. One of 
 > 
 > *--- Salvucci, D. D., & Goldberg, J. H. (2000, November). Identifying fixations and saccades in eye-tracking protocols. In Proceedings of the 2000 symposium on Eye tracking research & applications (pp. 71-78). ACM.*
 
-Pupil’s fixation detectors implement such dispersion-based algorithms. The exact procdure differs depending on whether fixations are detected in an online or offline context:
+Pupil Core's fixation detectors implement a dispersion-based method. The exact procedure differs depending on whether fixations are detected in an online or offline context:
 
 ### Online Fixation Detection
 
-In Pupil Capture, fixations are detected based on a dispersion threshold in terms of degrees of visual angle with a minimum duration. Fixation are published as soon as they comply with the constraints (dispersion and duration). This might result in a series of overlapping fixations.
+In Pupil Capture, fixations are detected based on a dispersion threshold in terms of degrees of visual angle with a minimum duration. Fixations are published as soon as they comply with the constraints (dispersion and duration). This might result in a series of overlapping fixations.
 
 - **Maximum Dispersion (spatial, degree):** Maximum distance between all gaze locations during a fixation.
 - **Minimum Duration (temporal, milliseconds):** The minimum duration in which the dispersion threshold must not be exceeded.

--- a/src/developer/core/network-api.md
+++ b/src/developer/core/network-api.md
@@ -200,7 +200,7 @@ incoming messages. Alternatively, you can use remote annotations.
 
 ### Fixation Messages
 
-The fixation detectors (online in Pupil Player and offline in Pupil Capture) publish the following notification:
+The Online Fixation Detector in Pupil Capture publishes the following notification:
 
 ```python
 {

--- a/src/developer/core/network-api.md
+++ b/src/developer/core/network-api.md
@@ -198,6 +198,42 @@ pub_socket.send(msgpack.dumps(payload, use_bin_type=True))
 The script above requires you to implement a custom [Plugin](#plugin-api) to process the
 incoming messages. Alternatively, you can use remote annotations.
 
+### Fixation Messages
+
+The fixation detectors (online in Pupil Player and offline in Pupil Capture) publish the following notification:
+
+```python
+{
+    'topic': 'fixation',
+    'start_timestamp': 534.5628765  # Timestamp of the first related gaze datum
+    'duration': 219.61850000002414  # Exact fixation duration, in milliseconds
+    'norm_pos_x': 0.4086194786082147  # Normalized x position of the fixation’s centroid
+    'norm_pos_y': 0.5458605572970497  # Normalized y position of the fixation’s centroid
+    'dispersion': 1.1102585185279166  # Dispersion, in degrees
+    'confidence': 0.9907119103981579  # Average pupil confidence
+    'method': '2d gaze'  # Which calibration method was used
+    'base_data': "545.53418 545.5361829999999 545.53817 ..."  # Timestamps of all data of the fixation
+}
+```
+
+When `method` is set to `3d gaze`, it will also contain the gaze point position:
+```python
+    # ...
+    'gaze_point_3d_x': -258.140474196683  # x position of mean 3d gaze point
+    'gaze_point_3d_y': 5.005121102396152  # y position of mean 3d gaze point
+    'gaze_point_3d_z': 463.9099936463522  # z position of mean 3d gaze point
+    # ...
+```
+
+The Offline Fixation Detector in Pupil Player additionally includes the following keys:
+```python
+    # ...
+    'start_frame_index': 679  # Index of the first related frame
+    'end_frame_index': 685  # Index of the last related frame
+    # ...
+```
+
+
 ### Remote Annotations
 You can also create [annotation](/core/software/pupil-capture/#annotations) events
 programmatically and send them using the IPC, or by sending messages to the Pupil Remote

--- a/src/developer/core/network-api.md
+++ b/src/developer/core/network-api.md
@@ -133,11 +133,11 @@ See the [data conventions](/developer/core/overview/#timing-data-conventions) an
 ## IPC Backbone Message Format
 All messages on the IPC Backbone are multipart messages containing (at least) two message frames:
 
- - `Frame 1` contains the [topic](/developer/core/overview/#timing-data-conventions) string, e.g. `pupil.0`, `logging.info`,
+ - `Frame 1` contains the [topic](#ipc-backbone-message-format) string, e.g. `pupil.0`, `logging.info`,
 `notify.recording.has_started`
 
  - `Frame 2` contains a [`msgpack`](https://msgpack.org/) encoded key-value mapping.
-This is the actual [message](#timing-data-conventions). We choose `msgpack` as the
+This is the actual [message](#ipc-backbone-message-format). We choose `msgpack` as the
 serializer due to its efficient format (45% smaller than `json`, 200% faster than
 `ujson`) and because encoders exist for almost every language.
 
@@ -148,7 +148,7 @@ Messages can have any topic chosen by the user. See topics below for a list of m
 
 Pupil data is sent from the eye0 and eye1 process with the topic `pupil.0` or `pupil.1`.
 Gaze mappers receive this data and publish messages with topic `gaze`. See the
-[Timing & Data Conventions](#pupil-datum-format) section for example messages for the
+[Timing & Data Conventions](/developer/core/overview/#pupil-datum-format) section for example messages for the
 `pupil` and `gaze` topics.
 
 ### Notification Message
@@ -195,7 +195,7 @@ pub_socket.send_string(topic, flags=zmq.SNDMORE)
 pub_socket.send(msgpack.dumps(payload, use_bin_type=True))
 ```
 
-The script above requires you to implement a custom [Plugin](#plugin-api) to process the
+The script above requires you to implement a custom [Plugin](/developer/core/plugin-api/) to process the
 incoming messages. Alternatively, you can use remote annotations.
 
 ### Fixation Messages


### PR DESCRIPTION
@willpatera Please have a look at my restructuring and rephrasing for fixation-detection related docs.

Please check if my way of writing the citation quote in markdown is acceptable. (file `terminology.md`):

> I-DT identifies fixations as groups of consecutive points within a particular dispersion, or maximum separation. Because fixations typically have a duration of at least 100 ms, dispersion-based identification techniques often incorporate a minimum duration threshold of 100-200 ms to help alleviate equipment variability.
> 
> *--- Salvucci, D. D., & Goldberg, J. H. (2000, November). Identifying fixations and saccades in eye-tracking protocols. In Proceedings of the 2000 symposium on Eye tracking research & applications (pp. 71-78). ACM.*

Closes #320 