### PR TITLE
Fix broken link to pupil helpers time sync

### DIFF
--- a/src/core/software/pupil-capture.md
+++ b/src/core/software/pupil-capture.md
@@ -332,7 +332,7 @@ each other.
 
 ::: tip
 <v-icon large color="info">info_outline</v-icon>
-See the <a href="https://github.com/pupil-labs/pupil-helpers/tree/master/pupil_sync">pupil-helpers</a> for example Python implementations.
+See the <a href="https://github.com/pupil-labs/pupil-helpers/tree/62ea54001fd051528bf24537bbd4f5f89e3391e8/network_time_sync">pupil-helpers</a> for example Python implementations.
 :::
 
 ::: tip


### PR DESCRIPTION
The `pupil_sync` in the pupil helpers repo has been deprecated a long time ago. I linked this to the current network time sync scripts in the helpers repo.

I specifically used GitHub permalinks, so we don't break out link so easily anymore. Does that make sense?