### PR TITLE
Add link to full marker PDF for tag36h11

### DIFF
--- a/src/core/software/pupil-capture.md
+++ b/src/core/software/pupil-capture.md
@@ -361,7 +361,10 @@ You can find more information on the legacy markers below.
 #### Markers
 There are many different Apriltag types, currently we support 7 families listed below. You can click on the links to download the individual markers from the [AprilTags repository](https://github.com/AprilRobotics/apriltag-imgs/tree/master/ "April Tags Github Repository"). For your convenience we have also prepared some tags from the **tag36h11** family in the two images below.
 
-If you want to generate your own marker sheets, you can find more information in the [the pupil-helpers repository](https://github.com/pupil-labs/pupil-helpers/tree/master/markers_stickersheet).
+Additionally, we created a PDF with one page per tag for all 587 tags from the **tag36h11** family here: [tag36h11_full.pdf](https://github.com/pupil-labs/pupil-helpers/blob/master/markers_stickersheet/tag36h11_full.pdf?raw=True).
+You can use this to print custom marker sheets by printing multiple pages per sheet.
+
+If you want to generate your own marker sheets or similar PDFs of other families, you can find more information in the [the pupil-helpers repository](https://github.com/pupil-labs/pupil-helpers/tree/master/markers_stickersheet).
 
 Supported Apriltag families:
 


### PR DESCRIPTION
I added the link to the new on-page-per-marker PDF in pupil-helpers.

@willpatera please see if it makes sense this way, I feel like this section start to become a bit cluttered. I was not sure where to put this best. Also we don't have a nice reference image.