### PR TITLE
Note on disinfectant potentially caucusing water damage

### DIFF
--- a/src/invisible/hardware/README.md
+++ b/src/invisible/hardware/README.md
@@ -54,6 +54,8 @@ All Pupil Invisible eye tracking glasses are cleaned with disinfectant prior to 
 
 The disinfectant we use is made from 22.0g Ethanol, 21.0g 2-Propanol, 8.0g 1-Propanol per 100 grams of solution. One such brand name that we use is "Vibasept". We use the wetted towlettes (wipes). Similar products should be available globally under different brand names.
 
+When applying the disinfectant, be careful around the eye cameras as liquid leaking into the sensor may cause water damage.
+
 ## Changing Lenses
 You can easily change the lenses of your Pupil Invisible glasses.
 

--- a/src/invisible/hardware/README.md
+++ b/src/invisible/hardware/README.md
@@ -54,7 +54,7 @@ All Pupil Invisible eye tracking glasses are cleaned with disinfectant prior to 
 
 The disinfectant we use is made from 22.0g Ethanol, 21.0g 2-Propanol, 8.0g 1-Propanol per 100 grams of solution. One such brand name that we use is "Vibasept". We use the wetted towlettes (wipes). Similar products should be available globally under different brand names.
 
-When applying the disinfectant, be careful around the eye cameras as liquid leaking into the sensor may cause water damage.
+Pupil Invisible is not water resistant. When cleaning, be careful around the eye cameras, world camera, and USB connection. Liquid from disinfectant might damage sensitive electronics inside the frame.  
 
 ## Changing Lenses
 You can easily change the lenses of your Pupil Invisible glasses.


### PR DESCRIPTION
Since multiple users seem to have caused water damages while disinfecting their devices around the eye sensors, I added a note to be careful around the eye cameras to the Disinfection section.