### PR TITLE
Add keyboard shortcuts overview

### DIFF
--- a/src/core/software/pupil-capture.md
+++ b/src/core/software/pupil-capture.md
@@ -22,6 +22,17 @@ The World window is the main control center for Pupil Capture. It displays a liv
 1. **Menu**: This area contains settings and contextual information for each plugin.
 1. **Sidebar**: This area contains clickable buttons for each plugin. System plugins are loaded in the top and user added plugins are added below a horizontal separator.
 
+### Keyboard Shortcuts
+
+| Keyboard Shortcut   | Description                                                  |
+|:--------------------|:-------------------------------------------------------------|
+| `r`                 | Start and stop recording                                     |
+| `c`                 | Start and stop calibration                                   |
+| `t`                 | Start and stop validation                                    |
+| `a`                 | Surface tracker: Add new surface                             |
+| `x`                 | Add annotation (default keyboard shortcut)                   |
+| `i`                 | Camera intrinsic estimation: Take snapshot of circle pattern |
+
 ## Video Source Selection
 By default Pupil Capture will use Local USB as the capture source.
 If you have a Pupil Core headset connected to your computer you will see videos displayed from your Pupil Core headset in the World and Eye windows.

--- a/src/core/software/pupil-player.md
+++ b/src/core/software/pupil-player.md
@@ -37,6 +37,19 @@ The Player window is the main control center for `Pupil Player`. It displays vid
 1. **Menu**: This area contains settings and contextual information for each plugin.
 1. **Sidebar**: This area contains clickable buttons for each plugin. System plugins are loaded in the top and user added plugins are added below the horizontal separator.
 
+### Keyboard Shortcuts
+
+| Keyboard Shortcut   | Description                                      |
+|:--------------------|:-------------------------------------------------|
+| `<space>`           | Play and pause video                             |
+| `<arrow left>`      | Step to previous frame / Decrease playback speed |
+| `<arrow right>`     | Step to next frame / Increase playback speed     |
+| `e`                 | Start export                                     |
+| `a`                 | Surface tracker: Add new surface                 |
+| `x`                 | Add annotation (default keyboard shortcut)       |
+| `f`                 | Fixation: Show next                              |
+| `F`                 | Fixation: Show previous                          |
+
 ## Workflow
 
 Pupil Player is similar to a video player. You can playback recordings and can load plugins to build visualizations.

--- a/src/core/software/pupil-player.md
+++ b/src/core/software/pupil-player.md
@@ -39,16 +39,19 @@ The Player window is the main control center for `Pupil Player`. It displays vid
 
 ### Keyboard Shortcuts
 
-| Keyboard Shortcut   | Description                                      |
-|:--------------------|:-------------------------------------------------|
-| `<space>`           | Play and pause video                             |
-| `<arrow left>`      | Step to previous frame / Decrease playback speed |
-| `<arrow right>`     | Step to next frame / Increase playback speed     |
-| `e`                 | Start export                                     |
-| `a`                 | Surface tracker: Add new surface                 |
-| `x`                 | Add annotation (default keyboard shortcut)       |
-| `f`                 | Fixation: Show next                              |
-| `F`                 | Fixation: Show previous                          |
+| Keyboard Shortcut   | Description                                            |
+|:--------------------|:-------------------------------------------------------|
+| `<space>`           | Play and pause video                                   |
+| `<arrow left>`      | Step to previous frame\* / Decrease playback speed\*\* |
+| `<arrow right>`     | Step to next frame\* / Increase playback speed\*\*     |
+| `e`                 | Start export                                           |
+| `a`                 | Surface tracker: Add new surface                       |
+| `x`                 | Add annotation (default keyboard shortcut)             |
+| `f`                 | Fixation: Show next                                    |
+| `F`                 | Fixation: Show previous                                |
+
+\* While paused
+\*\* During playback
 
 ## Workflow
 


### PR DESCRIPTION
This PR adds keyboard shortcuts overview tables to Pupil Capture and Pupil Player docs.

Depends on [this PR](https://github.com/pupil-labs/pupil/pull/2129) being merged.

---

[ClickUp Task](https://app.clickup.com/t/gq33tk)
