### PR TITLE
Added reference image to export docs

### DIFF
--- a/src/cloud/enrichments/README.md
+++ b/src/cloud/enrichments/README.md
@@ -184,6 +184,8 @@ This file contains all the mapped gaze data from all sections.
 | **gaze position in reference image y [px]** | Same as "gaze position in reference image x [px]" but for the y-coordinate.     |
 
 
+#### Reference Image
+The reference image used for defining the enrichment. It has the same name and file extension as the original file.
 
 ## Gaze Overlay
 <div class="pb-4" style="display:flex;justify-content:center;filter:drop-shadow(2px 4px 10px #000000);">

--- a/src/cloud/enrichments/README.md
+++ b/src/cloud/enrichments/README.md
@@ -185,7 +185,7 @@ This file contains all the mapped gaze data from all sections.
 
 
 #### Reference Image
-The reference image used for defining the enrichment. It has the same name and file extension as the original file.
+The reference image used for defining the enrichment. The file is named `reference_image.jpeg|png`
 
 ## Gaze Overlay
 <div class="pb-4" style="display:flex;justify-content:center;filter:drop-shadow(2px 4px 10px #000000);">


### PR DESCRIPTION
The reference image mapper export now contains the reference image as well. This is the respective doc entry for that file.

To be merged once v5.3 of cloud is released.