### PR TITLE
Added citation instructions for PI, update for Core

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -74,7 +74,8 @@ module.exports = {
             'user-guide/invisible-companion-app',
             'user-guide/invisible-monitor',
             'user-guide/analysis',
-            'user-guide/troubleshooting'
+            'user-guide/troubleshooting',
+            'user-guide/academic-citation',
           ]
         }
       ],

--- a/src/core/academic-citation.md
+++ b/src/core/academic-citation.md
@@ -6,11 +6,13 @@ description: Writing an academic paper that uses Pupil Labs products? Please cit
 
 # Academic Citation
 
-We have been asked a few times about how to cite Pupil in academic research. Please take a look at our papers below for citation options. If you're using Pupil as a tool in your research please cite the below UbiComp 2014 paper.
+We have been asked a few times about how to cite Pupil Core in academic research. Please take a look at our papers below for citation options. If you're using Pupil Core as a tool in your research please cite the below UbiComp 2014 paper.
 
-## Papers that cite Pupil
+For guidance on citing Pupil Invisible please see [here](/invisible/academic-citation).
 
-We have compiled a list of publications that cite Pupil in this [spreadsheet](https://docs.google.com/spreadsheets/d/1ZD6HDbjzrtRNB4VB0b7GFMaXVGKZYeI0zBOBEEPwvBI/edit?ts=576a3b27#gid=0)
+## Papers that cite Pupil Core
+
+We have compiled a list of academic publications that use Pupil Labs products. You can find it [here](https://pupil-labs.com/publications/)!
 
 ## UbiComp 2014 Paper
 

--- a/src/invisible/user-guide/academic-citation.md
+++ b/src/invisible/user-guide/academic-citation.md
@@ -1,0 +1,61 @@
+---
+permalink: /invisible/academic-citation
+description: Writing an academic paper that uses Pupil Labs products? Please cite us!
+
+---
+
+# Academic Citation
+
+If you are using are using Pupil Invisible in academic research, please cite the following paper in your publications! For guidance on citing Pupil Core please see [here](/core/academic-citation).
+
+#### Title
+
+A High-Level Description and Performance Evaluation of Pupil Invisible
+
+#### Abstract
+
+Head-mounted eye trackers promise convenient
+access to reliable gaze data in unconstrained environments. Due
+to several limitations, however, often they can only partially
+deliver on this promise.
+Among those are the following: (i) the necessity of performing
+a device setup and calibration prior to every use of the eye
+tracker, (ii) a lack of robustness of gaze-estimation results
+against perturbations, such as outdoor lighting conditions and
+unavoidable slippage of the eye tracker on the head of the
+subject, and (iii) behavioral distortion resulting from social
+awkwardness, due to the unnatural appearance of current
+head-mounted eye trackers.
+Recently, Pupil Labs released Pupil Invisible glasses,
+a head-mounted eye tracker engineered to tackle these
+limitations. Here, we present an extensive evaluation of
+its gaze-estimation capabilities. To this end, we designed a
+data-collection protocol and evaluation scheme geared towards
+providing a faithful portrayal of the real-world usage of Pupil
+Invisible glasses.
+In particular, we develop a geometric framework for gauging
+gaze-estimation accuracy that goes beyond reporting mean
+angular accuracy. We demonstrate that Pupil Invisible glasses,
+without the need of a calibration, provide gaze estimates
+which are robust to perturbations, including outdoor lighting
+conditions and slippage of the headset.
+
+#### Permalink to article
+
+Available on arxiv: [https://arxiv.org/pdf/2009.00508.pdf](https://arxiv.org/pdf/2009.00508.pdf)
+
+> BibTeX Style Citation
+
+```
+@article{tonsen2020high,
+  title={A High-Level Description and Performance Evaluation of Pupil Invisible},
+  author={Tonsen, Marc and Baumann, Chris Kay and Dierkes, Kai},
+  journal={arXiv preprint arXiv:2009.00508},
+  year={2020}
+}
+```
+
+## Papers that cite Pupil Invisible
+
+We have compiled a list of academic publications that use Pupil Labs products. You can find it [here](https://pupil-labs.com/publications/)!
+


### PR DESCRIPTION
In order to increase the likelihood of PI being cited correctly (previous citations used the product website) I updated citation instructions in docs.

- Updated link to citations to point to website rather than spread sheet.
- Updated naming of Pupil Core from "Pupil" to "Pupil Core" in this context.
- Added analogous citation section for Pupil Invisible.
- Added references to one another.