### PR TITLE
Pupil Remote transmission-delay warning

### DIFF
--- a/src/core/developer/network-api.md
+++ b/src/core/developer/network-api.md
@@ -74,6 +74,14 @@ This is an overview over all available Pupil Remote commands:
 'SUB_PORT'  # return the current sub port of the IPC Backbone
 ```
 
+:::danger Delayed Execution
+Sending a command takes time to be transmitted. In other words, a command is only
+executed in Pupil Capture after some short delay. This is especially important to keep
+in mind for the `T`, `t`, and `R` commands. See our
+[Best Practices](/core/best-practices/#synchronization) regarding time synchronization.
+<br/><br/>Do not rely on the sent time-point of `R` for time sychnronization!
+:::
+
 ::: tip
 <v-icon large color="info">info_outline</v-icon>
 Pupil Service does not support the creation of recordings, i.e. the `R` and `r` commands

--- a/src/core/developer/network-api.md
+++ b/src/core/developer/network-api.md
@@ -75,11 +75,8 @@ This is an overview over all available Pupil Remote commands:
 ```
 
 :::danger Delayed Execution
-Sending a command takes time to be transmitted. In other words, a command is only
-executed in Pupil Capture after some short delay. This is especially important to keep
-in mind for the `T`, `t`, and `R` commands. See our
-[Best Practices](/core/best-practices/#synchronization) regarding time synchronization.
-<br/><br/>Do not rely on the sent time-point of `R` for time sychnronization!
+Pupil Remote commands can be subject to transmission delay (e.g. from network latency). This is especially important to keep in mind for the `T`, `t`, and `R` commands. 
+<br/><br/>We do not recommend using `R` for time synchronization. In addition to transmission delay, not all recording processes are guaranteed to start simultaneously when Pupil Capture receives the command. Please read our [Best Practices](/core/best-practices/#synchronization) for more appropriate methods of time synchronization. 
 :::
 
 ::: tip


### PR DESCRIPTION
Warn users about the transmission delay for Pupil Remote commands and its implications.

This is how it would look like:

![Screenshot 2022-02-21 at 11 24 44](https://user-images.githubusercontent.com/168390/154936470-ffe93376-3926-484a-a98c-1b310617173f.png)

@N-M-T I would appreciate your input, especially regarding the wording of the warning. Should we more explicit about the consequences of the transmission delay?