### PR TITLE
Notebook build issue workaround: Add `packaging` requirement

### DIFF
--- a/.github/workflows/build-deploy-production.yml
+++ b/.github/workflows/build-deploy-production.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - run: pip install nbconvert
+      - run: pip install nbconvert packaging
       - name: Convert Jupyter notebooks
         run: |
           shopt -s globstar

--- a/.github/workflows/build-deploy-staging.yml
+++ b/.github/workflows/build-deploy-staging.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - run: pip install nbconvert
+      - run: pip install nbconvert packaging
       - name: Convert Jupyter notebooks
         run: |
           shopt -s globstar

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - run: pip install nbconvert
+      - run: pip install nbconvert packaging
       - name: Convert Jupyter notebooks
         run: |
           shopt -s globstar


### PR DESCRIPTION
Build failed due to missing `packaging` requirement.
See https://github.com/pupil-labs/pupil-docs/runs/5882123222?check_suite_focus=true

Looks like nbconvert relies on packaging without mentioning it directly as a dependency.
Instead, it looks like packaging was installed indirectly via a different dependency until now.