### PR TITLE
	modified documentation of pupil core, few typos and fix broken link 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,4 +221,3 @@ cython_debug/
 #.idea/
 
 # End of https://www.toptal.com/developers/gitignore/api/jupyternotebooks,python
-changelog.txt

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ contents/css
 contents/js/*.js
 assets/rev_manifest
 rev_manifest.json
-changelog.txt #mgg just to write the commit message
-
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ contents/css
 contents/js/*.js
 assets/rev_manifest
 rev_manifest.json
+changelog.txt #mgg just to write the commit message
+
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
@@ -221,3 +223,4 @@ cython_debug/
 #.idea/
 
 # End of https://www.toptal.com/developers/gitignore/api/jupyternotebooks,python
+changelog.txt

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -12,7 +12,7 @@ Follow the steps below to get up and running and become familiar with the workfl
 <v-divider></v-divider>
 
 ## 1. Put on Pupil Core
-Put on Pupil Core headset and plug it in to your computer.
+Put on the Pupil Core headset and plug it into your computer.
 
 Make sure there is space between the headset frame and your forehead. Headsets are adjustable and shipped with additional parts. For more information head over to the [Hardware](/core/hardware/ "Pupil Core hardware documentation") section of the docs.
 
@@ -42,7 +42,7 @@ Pupil Core uses a 3D model of the eye to improve the pupil detection. Adjust the
 <Youtube src="7wuVCwWcGnE"/>
 
 
-Slowly move your eyes around until the eye model (green circle) adjusted to fit your eye ball. If everything is set up properly, you should see a green circle around the eye ball and a red circle around the pupil with a red dot in the center.
+Slowly move your eyes around until the eye model (green circle) adjusted to fit your eyeball. If everything is set up properly, you should see a green circle around the eyeball and a red circle around the pupil with a red dot in the center.
 
 Next, check the world window.
 
@@ -60,7 +60,7 @@ In order to know what someone is looking at, we must establish a mapping between
 <Videos :src="require(`../media/core/videos/clb-hd.mp4`)" />
 
 #### Screen Marker Calibration Method
-Click `c` on the world screen or press `c` on the keyboard to start calibrate.
+Click `c` on the world screen or press `c` on the keyboard to start calibrating.
 Follow the marker on the screen with your eyes and try to keep your head stationary.
 
 <Videos :src="require(`../media/core/videos/clb-s.mp4`)" />
@@ -83,14 +83,14 @@ Pupil Capture will save the world video stream and all the corresponding gaze da
 
 By default, each recording will live in its own unique data folder contained in the recordings folder.
 
-The default recordings directory will organize all recordings by date. Each time you press record a new folder will be created. Below we show an example of 3 recordings that have been made on the same date `001`, `002`, and `003`:
+The default recordings directory will organize all recordings by date. Each time you press record a new folder will be created. Below we show an example of 3 recordings that have been made on the same date `000`, `001`, and `002`:
 
 ```
 recordings/
   2019-09-30/
+    000/
     001/
     002/
-    003/
 ```
 
 ## 7. Visualize in Pupil Player

--- a/src/core/academic-citation.md
+++ b/src/core/academic-citation.md
@@ -8,7 +8,7 @@ description: Writing an academic paper that uses Pupil Labs products? Please cit
 
 We have been asked a few times about how to cite Pupil Core in academic research. Please take a look at our papers below for citation options. If you're using Pupil Core as a tool in your research please cite the below UbiComp 2014 paper.
 
-For guidance on citing Pupil Invisible please see [here](/invisible/academic-citation).
+For guidance on citing Pupil Invisible please see [here](https://docs.pupil-labs.com/invisible/explainers/publications.html).
 
 ## Papers that cite Pupil Core
 

--- a/src/core/academic-citation.md
+++ b/src/core/academic-citation.md
@@ -8,7 +8,7 @@ description: Writing an academic paper that uses Pupil Labs products? Please cit
 
 We have been asked a few times about how to cite Pupil Core in academic research. Please take a look at our papers below for citation options. If you're using Pupil Core as a tool in your research please cite the below UbiComp 2014 paper.
 
-For guidance on citing Pupil Invisible please see [here](https://docs.pupil-labs.com/invisible/explainers/publications.html).
+For guidance on citing Pupil Invisible please see [here](/invisible/explainers/publications.html).
 
 ## Papers that cite Pupil Core
 

--- a/src/core/software/pupil-capture.md
+++ b/src/core/software/pupil-capture.md
@@ -210,7 +210,7 @@ With the 2D Gaze Mapping, you should easily be able to achieve tracking accuracy
 ## Recording
 <Videos :src="require(`../../media/core/videos/rec.mp4`)" />
 
-Press `r` on your keyboard or press the blue circular `R` button on the left hand side of the world window to start recording. You will see red text with the elapsed time of recording next to the `R` button. To stop recording, press `r` on your keyboard or press the `R` button on screen.
+Press `r` on your keyboard or press the circular `R` button on the left hand side of the world window to start recording. You will see red text with the elapsed time of recording next to the `R` button. To stop recording, press `r` on your keyboard or press the `R` button on screen.
 
 You can change recording settings in the `Recorder` plugin menu. Set the folder where recordings are saved under `Path to recordings`. Set the recording name in `Recording session name`.
 

--- a/src/core/software/pupil-player.md
+++ b/src/core/software/pupil-player.md
@@ -63,7 +63,7 @@ Here is an example workflow:
 - Open a Plugin - From the `Plugin Manager` GUI menu load the `Vis Circle` plugin.
 - Playback - press the play button or `space` bar on your keyboard to view the video playback with visualization overlay, or drag the playhead in the seek bar to scrub through the dataset.
 - Set trim marks - you can drag the green rounded rectangle at the beginning and end of the seekbar to set the trim marks. This will set the start and end frame for the exporter and for other plugins.
-- Export Video & Raw Data - From the `Plugin Manager` view, load the `World Video Exporter` plugin and the `Raw Data Exporter` plugin. Press `e` on your keyboard or the `e` button in the left hand side of the window to start the export.
+- Export Video & Raw Data - From the `Plugin Manager` view, load the `World Video Exporter` plugin and the `Raw Data Exporter` plugin. Press `e` on your keyboard or the `download icon` button in the left hand side of the window to start the export.
 - Check out exported data in the `exports` directory within your recording directory
 
 ::: tip


### PR DESCRIPTION
    misc. add articles, change eye ball to eyeball.

	modified:   src/core/academic-citation.md
    Link to how to cite invisible was broken (404), modified, however, it is hard-coded to the URL not using local ones, feel free to change it.

	modified:   src/core/software/pupil-capture.md
    On recording it refers to a "blue circular R", r is not blue, so removed.

	modified:   src/core/software/pupil-player.md
    e - hotkey is not shown as "e" but as download icon. Changed to reflect this.

    mgg 220705