### PR TITLE
Link checker actions to look for broken links in the docs

### DIFF
--- a/.github/workflows/link-check-on-pr.yml
+++ b/.github/workflows/link-check-on-pr.yml
@@ -14,10 +14,14 @@ jobs:
           fetch-depth: 2
 
       # Gets a list of files from the PR with a git status of Added (A) or Modified (M) | (via outputs.all_changed_files)
-      - name: 'Example - Get a list of changed files to process'
+      - name: 'Example - Get a list of changed files to process(Only html/md/ipynb files)'
         id: get-changed-files
-        uses: tj-actions/changed-files@v23
+        uses: tj-actions/changed-files@v24
         with:
+          files: |
+            **/*.html
+            **/*.md
+            **/*.ipynb
           separator: ','
 
       # lychee-action requires pre-processing for file paths with spaces (boundary quotes added in lychee-action input):
@@ -31,7 +35,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.5.0
         with:
-          args: -v -n -a 403,503,429,200 --cache -i -b 'https://docs.pupil-labs.com/' --include-verbatim -- '${{ steps.changed-files.outputs.all_changed_files }}'
+          args: -v -n -a 403,503,429,200 --cache -i -b 'https://docs.pupil-labs.com/' --exclude-mail --include-verbatim -- '${{ steps.changed-files.outputs.all_changed_files }}'
           jobSummary: true
           lycheeVersion: 0.10.0
           output: /tmp/out.txt

--- a/.github/workflows/link-check-on-pr.yml
+++ b/.github/workflows/link-check-on-pr.yml
@@ -1,0 +1,51 @@
+name: Links check on PR
+
+on:
+  pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Test changed-files
+    steps:
+      # Compares the default generated "test merge commit" by Github of the PR branch into the base branch
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      # Gets a list of files from the PR with a git status of Added (A) or Modified (M) | (via outputs.all_changed_files)
+      - name: 'Example - Get a list of changed files to process'
+        id: get-changed-files
+        uses: tj-actions/changed-files@v23
+        with:
+          separator: ','
+
+      # lychee-action requires pre-processing for file paths with spaces (boundary quotes added in lychee-action input):
+      - name: 'Compatibility with eval: Quote wrap paths to support spaces'
+        id: changed-files
+        run: |
+          QUOTE_WRAPPED="$( sed "s/,/' '/g" <<< '${{ steps.get-changed-files.outputs.all_changed_files }}' )"
+          echo "::set-output name=all_changed_files::${QUOTE_WRAPPED}"
+
+      - name: 'Check Links'
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.5.0
+        with:
+          args: -v -n -a 403,503,429,200 --cache -i -b 'https://docs.pupil-labs.com/' --include-verbatim -- '${{ steps.changed-files.outputs.all_changed_files }}'
+          jobSummary: true
+          lycheeVersion: 0.10.0
+          output: /tmp/out.txt
+
+      - id: get-comment-body
+        run: |
+          body="$(cat /tmp/out.txt)"
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}" 
+          echo "::set-output name=body::$body"
+
+      - name: Create comment
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: ${{ steps.get-comment-body.outputs.body }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-check-on-req.yml
+++ b/.github/workflows/link-check-on-req.yml
@@ -1,0 +1,65 @@
+name: Links check on REQ  
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+
+jobs:
+  linkChecker:
+    name: Install dependencies and generate static site and check for broken links
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - run: pip install nbconvert packaging
+
+      - name: Convert Jupyter notebooks
+        run: |
+          shopt -s globstar
+          jupyter-nbconvert --to markdown **/*.ipynb --ExtractOutputPreprocessor.enabled=False
+          shopt -u globstar
+        shell: bash
+
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      
+      - name: Install vuepress
+        run: yarn global add vuepress
+
+      - name: Install package.json
+        run: yarn
+
+      - name: Build static site with vuepress
+        # alias for vuepress build src defined in package.json
+        run: yarn build
+      
+      - name: Get size of files in dist 
+        shell: bash
+        run: |
+          du -ah src/.vuepress/dist
+
+      # Check built html pages for broken links
+      - name: Link checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.5.0
+        with:
+        # Check all markdown and html files in repo (exclude those in .lycheeignore)
+          args: -v -n -a 403,503,429,200 --cache -i -u 'Mozilla/5.0' -b 'https://docs.pupil-labs.com' --exclude-mail --include-verbatim 'src/.vuepress/**/*.html' #'src/core/**/*.md' 'src/invisible/**/*.md' 'src/vr-ar/**/*.md' 'src/**/*.md' 'src/invisible/**/*.ipynb' 'src/core/**/*.ipynb'
+          jobSummary: true
+          lycheeVersion: 0.10.0
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create Issue From File from lychee
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue
+          

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -18,5 +18,17 @@ file:///**/*.js
 # Ignore all .mp4 files
 ./*.mp4
 
+# Ignore all .jpg files
+./*.jpg
+
+# Ignore all .jpeg files
+./*.jpeg
+
+# Subscribe email, needs right post request to the endpoint
+https://mailchimp.us3.list-manage.com/subscribe/post
+
+# Too many redirects but it works
+http://doi.acm.org/10.1145/2638728.2641695
+
 # Ignore all files
 # file:///

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -12,10 +12,10 @@ file:///**/*.js
 # Ignore all .svg files
 ./*.svg
 
-# Ignore all .svg files
+# Ignore all .png files
 ./*.png
 
-# Ignore all .svg files
+# Ignore all .mp4 files
 ./*.mp4
 
 # Ignore all files

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,22 @@
+# Ignore local address
+http://pi.local:8080/
+localhost:%25s
+
+# Ignore all .js files
+file:///**/*.js
+./*.js
+
+# Ignore all .css files
+./*.css
+
+# Ignore all .svg files
+./*.svg
+
+# Ignore all .svg files
+./*.png
+
+# Ignore all .svg files
+./*.mp4
+
+# Ignore all files
+# file:///


### PR DESCRIPTION
	new file:   .github/workflows/link-check-on-pr.yml

    On every PR, check if new links are broken and adds a comment to the PR with the results.
    As of now, this action does not build and check for the HTML files but parses the files changed directly.

    Known issues:
    - Youtube links in MD files are reported as broken even though they are not, just because only the ID is given.

	new file:   .github/workflows/link-check-on-req.yml

    Under request. This action can be called from the action panel/workflows.
    It will build the Vuepress site and check the links only on HTML files.
    It will write the results to an issue in the repo.
    It might be worth changing it to run monthly.

    Notes: Currently accepted codes are 403,503, 429 and 200.

	new file:   .lycheeignore
    Just to place which webs shall be ignored, such as pi.local:8080 or localhost:8080, or those leading to the static files(js, images, etc.)