### PR TITLE
No comments in PR if all links are right

### DIFF
--- a/.github/workflows/link-check-on-pr.yml
+++ b/.github/workflows/link-check-on-pr.yml
@@ -57,7 +57,6 @@ jobs:
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}" 
           echo "::set-output name=body::$body"
-          
       - name: Create comment
         if: steps.lychee.outputs.exit_code == 2
         uses: thollander/actions-comment-pull-request@v1

--- a/.github/workflows/link-check-on-pr.yml
+++ b/.github/workflows/link-check-on-pr.yml
@@ -30,13 +30,6 @@ jobs:
         run: |
           QUOTE_WRAPPED="$( sed "s/,/' '/g" <<< '${{ steps.get-changed-files.outputs.all_changed_files }}' )"
           echo "::set-output name=all_changed_files::${QUOTE_WRAPPED}"
-          
-      # - name: Restore lychee cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: .lycheecache
-      #     key: cache-lychee-${{ github.sha }}
-      #     restore-keys: cache-lychee-
 
       - name: 'Check Links'
         id: lychee
@@ -46,8 +39,6 @@ jobs:
           lycheeVersion: 0.10.1
           output: lychee/results.md
           jobSummary: true
-
-      # --cache --max-cache-age 1d
 
       - id: get-comment-body
         if: steps.lychee.outputs.exit_code == 2

--- a/.github/workflows/link-check-on-pr.yml
+++ b/.github/workflows/link-check-on-pr.yml
@@ -66,5 +66,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Fail workflow if link broken
-        if: steps.lychee.outputs.exit_code !=0
+        if: steps.lychee.outputs.exit_code == 2
         run: exit 1

--- a/.github/workflows/link-check-on-pr.yml
+++ b/.github/workflows/link-check-on-pr.yml
@@ -30,26 +30,41 @@ jobs:
         run: |
           QUOTE_WRAPPED="$( sed "s/,/' '/g" <<< '${{ steps.get-changed-files.outputs.all_changed_files }}' )"
           echo "::set-output name=all_changed_files::${QUOTE_WRAPPED}"
+          
+      # - name: Restore lychee cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: .lycheecache
+      #     key: cache-lychee-${{ github.sha }}
+      #     restore-keys: cache-lychee-
 
       - name: 'Check Links'
         id: lychee
-        uses: lycheeverse/lychee-action@v1.5.0
+        uses: lycheeverse/lychee-action@v1.5.1
         with:
-          args: -v -n -a 403,503,429,200 --cache -i -b 'https://docs.pupil-labs.com/' --exclude-mail --include-verbatim -- '${{ steps.changed-files.outputs.all_changed_files }}'
+          args: -v -n -a 403,503,429,200 -i -b 'https://docs.pupil-labs.com/' --exclude-mail --include-verbatim -- '${{ steps.changed-files.outputs.all_changed_files }}'
+          lycheeVersion: 0.10.1
+          output: lychee/results.md
           jobSummary: true
-          lycheeVersion: 0.10.0
-          output: /tmp/lychee/out.md
+
+      # --cache --max-cache-age 1d
 
       - id: get-comment-body
+        if: steps.lychee.outputs.exit_code == 2
         run: |
-          body="$(echo "# Link check summary"; cat /tmp/lychee/out.md)"
+          body="$(echo "# Link check summary"; cat lychee/results.md)"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}" 
           echo "::set-output name=body::$body"
-
+          
       - name: Create comment
+        if: steps.lychee.outputs.exit_code == 2
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: ${{ steps.get-comment-body.outputs.body }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Fail workflow if link broken
+        if: steps.lychee.outputs.exit_code !=0
+        run: exit 1


### PR DESCRIPTION
Updated dependency to 1.5.1, which solves a bug where the exit code was not propagated.

Eliminated --cache param as only gave errors and is not needed.

Fail workflow action if a broken link is found.