### PR TITLE
Fixed broken links

### DIFF
--- a/src/core/developer/overview.md
+++ b/src/core/developer/overview.md
@@ -6,7 +6,7 @@ description: Welcome to Pupil Core developer documentation.
 # Overview
 
 Welcome to Pupil Core developer documentation. If you haven't already, we
-highly recommend reading the [_Getting Started_](/core/#getting-started) section and the [_User Guide_](/core/software/pupil-capture.html), before continuing with the developer documentation.
+highly recommend reading the [_Getting Started_](/core/#getting-started) section and the [_User Guide_](/core/software/pupil-capture), before continuing with the developer documentation.
 
 Have a question? Get in touch with developers and other community members on the `#pupil-software-dev`
 channel on [Discord](https://pupil-labs.com/chat).
@@ -162,7 +162,7 @@ topic and the `timestamp` (inherited from the eye image), the pupil detector add
 - `confidence`: Value indicating quality of the measurement
 
 By default, the Pupil Core software uses the
-[3d detector](/core/software/pupil-capture.html#pupil-detection) for pupil detection.
+[3d detector](/core/software/pupil-capture#pupil-detection) for pupil detection.
 Since it is an extension of the 2d detector, its data contains keys that were
 inherited from the 2d detection, as well as 3d detector specific keys. The minimal set of keys needed in a valid pupil datum object is: `id`, `topic`, `method`, `norm_pos`, `diameter`, `timestamp`, and `confidence`. Below you can
 see the Python representation of a 3d pupil datum:

--- a/src/core/developer/plugin-api.md
+++ b/src/core/developer/plugin-api.md
@@ -26,7 +26,7 @@ user's home directory and follows this naming convention: `pupil_<name>_settings
 Each user directory has a `plugins` subdirectory into which the plugin files need to be
 placed. The Pupil Core software will attempt to load the files during the next launch.
 
-If the plugin was installed correctly, it should appear in the [Plugin Manager](/core/software/pupil-capture.html#plugins)
+If the plugin was installed correctly, it should appear in the [Plugin Manager](/core/software/pupil-capture/#plugins)
 of the corresponding Pupil Core software. Check the log file (`~/pupil_<name>_settings/<name>.log`) for errors if this is not the case.
 
 ::: warning

--- a/src/core/developer/recording-format.md
+++ b/src/core/developer/recording-format.md
@@ -28,7 +28,7 @@ will be transformed the Pupil Player Recording Format 2.0.
 Timestamp files must follow this strict naming convention:
 Given that a data file is named `<name>.<ext>` then its timestamps file has to be named `<name>_timestamps.npy`.
 
-Timestamp files are saved in the [NPY binary format](https://docs.scipy.org/doc/numpy/neps/npy-format.html). You can use [`numpy.load()`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.load.html#numpy.load) to access the timestamps in Python.
+Timestamp files are saved in the [NPY binary format](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html#module-numpy.lib.format). You can use [`numpy.load()`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.load.html#numpy.load) to access the timestamps in Python.
 
 A datum and its timestamp have the same index within their respective files, i.e. the `i`th timestamp in `world_timestamps.npy` belongs to the `i`th video frame in `world.mp4`.
 

--- a/src/core/software/pupil-player.md
+++ b/src/core/software/pupil-player.md
@@ -345,8 +345,7 @@ and roll axes using accelerometer feedback to monitor position relative to gravi
 
 In the Plugin's menu, toggle `View raw timeline` to view the accelerometer and gyroscope readings and `View orientation
 timeline` for pitch and roll. You can also change `Madgwick's beta`. This value is associated with gyroscope mean error.
-Increasing the beta will lead to faster drift corrections but with more sensitivity to lateral accelerations. Read more
-about [Madgwick's algorithm here](https://www.x-io.co.uk/res/doc/madgwick_internal_report.pdf).
+Increasing the beta will lead to faster drift corrections but with more sensitivity to lateral accelerations. Read more about [Madgwick's algorithm here](https://x-io.co.uk/downloads/madgwick_internal_report.pdf).
 
 Results are exported in `imu_timeline.csv` with the following columns:
 | Key                 | Description                                                            |
@@ -362,14 +361,13 @@ Results are exported in `imu_timeline.csv` with the following columns:
 | `pitch`             | Orientation about the x-axis (head tilt from front to back) in degrees |
 | `roll`              | Orientation about the z-axis (head tilt from side to side) in degrees  |
 
-:::tip
+<!-- :::tip
 <v-icon large color="info">info_outline</v-icon>
 Read more about [Pupil Invisible's coordinate systems here](/developer/invisible/#coordinate-systems).
-:::
+::: -->
 
 This Plugin does not estimate orientation about the yaw axis (head rotation from left to right). This is 
-because the IMU has no magnetometer to monitor heading. The Plugin therefore implements a version of Madgwick's
-algorithm that only estimates Pitch and Roll.
+because the IMU has no magnetometer to monitor heading. The Plugin therefore implements a version of Madgwick's algorithm that only estimates Pitch and Roll.
 
 Note that this Plugin [will not be loaded](/core/software/pupil-player/#product-specific-plugins) with Pupil Core recordings.
 

--- a/src/invisible/how-tos/integrate-with-the-real-time-api/track-your-experiment-progress-using-events/README.ipynb
+++ b/src/invisible/how-tos/integrate-with-the-real-time-api/track-your-experiment-progress-using-events/README.ipynb
@@ -103,7 +103,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That is all we have to do during data collection. Once all recordings have uploaded to Pupil Cloud, we create a project with them in order to export them using the [Raw Data Exporter](/invisible/explainers/enrichments/raw-data-exporter). In the project editor we can already see the events in every recording.\n",
+    "That is all we have to do during data collection. Once all recordings have uploaded to Pupil Cloud, we create a project with them in order to export them using the [Raw Data Exporter](/invisible/explainers/enrichments/#raw-data-exporter). In the project editor we can already see the events in every recording.\n",
     "\n",
     "<div style=\"display:flex;justify-content:center;\" class=\"pb-4\">\n",
     "  <v-img\n",


### PR DESCRIPTION
This PR fixes all the broken links found.

Note: Converting .ipynb notebooks to .md still causes broken links at the bottom of the page, as the edit button will lead to a non-existent markdown file in this repo.