### PR TITLE
Update node.js in Actions to 16 LTS

### DIFF
--- a/.github/workflows/build-deploy-production.yml
+++ b/.github/workflows/build-deploy-production.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - run: pip install nbconvert packaging
@@ -25,9 +25,9 @@ jobs:
         shell: bash
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "12.x"
+          node-version: 16
 
       - name: Install vuepress
         run: yarn global add vuepress
@@ -62,7 +62,7 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download generated website dist dir
         uses: actions/download-artifact@v2
@@ -89,7 +89,7 @@ jobs:
       url: https://docs.pupil-labs.com
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download generated website dist dir
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-deploy-staging.yml
+++ b/.github/workflows/build-deploy-staging.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - run: pip install nbconvert packaging
@@ -23,9 +23,9 @@ jobs:
         shell: bash
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "12.x"
+          node-version: 16
 
       - name: Install vuepress
         run: yarn global add vuepress
@@ -60,7 +60,7 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download generated website dist dir
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-deploy-staging.yml
+++ b/.github/workflows/build-deploy-staging.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@3
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This will fix issue #552.
I've updated checkout actions to v3, setup-python to v4 and setup-node to v3. And ofc updated the node-version to the LTS version 16.

I've tested it in staging, and the GH action works fine.