### PR TITLE
Add fixation detector whitepaper download

### DIFF
--- a/src/invisible/basic-concepts/data-streams.md
+++ b/src/invisible/basic-concepts/data-streams.md
@@ -63,9 +63,7 @@ Traditionally, fixation detection algorithms assumed the head of the subject to 
 If head movements occur during a fixation, compensatory eye movements are required to keep gaze stable on the point of fixation. These are initiated by the 
 vestibulo-ocular reflex (VOR). 
 
-Our algorithm explicitly compensates for VOR eye movements and thus correctly classifies fixations in more dynamic scenarios!
-
-The algorithm will soon be released with an open-source licence. Further, we are currently working on a white paper that describes the algorithm in detail and evaluates it thoroughly.
+Our algorithm explicitly compensates for VOR eye movements and thus correctly classifies fixations in more dynamic scenarios! Read more about that in the [Pupil Labs fixation detector whitepaper](https://docs.google.com/document/d/1dTL1VS83F-W1AZfbG-EogYwq2PFk463HqwGgshK3yJE/export?format=pdf)
 
 ## Blinks
 During blinks the eye is briefly covered by the eye lids, which serves the purpose of spreading tears across the cornea. The blink rate and blink duration are however also correlated with cognitive processes, which makes it an interesting physiological signal.

--- a/src/neon/basic-concepts/data-streams.md
+++ b/src/neon/basic-concepts/data-streams.md
@@ -43,7 +43,7 @@ The two primary types of eye movements exhibited by the visual system are fixati
 
 Fixations are calculated automatically in Pupil Cloud after uploading a recording and are included in relevant downloads. The downloads for gaze mapping enrichments ([Reference Image Mapper](/neon/reference/export-formats/#fixations-csv-3), [Marker Mapper](/neon/reference/export-formats/#fixations-csv-2)) also include "mapped fixations".
 
-The deployed fixation detection algorithm was specifically designed for head-mounted eye trackers and offers increased robustness in the presence of head-movements. Especially movements due to vestibulo-ocular reflex are compensated for, which is not the case for most other fixation detection algorithms. 
+The deployed fixation detection algorithm was specifically designed for head-mounted eye trackers and offers increased robustness in the presence of head-movements. Especially movements due to vestibulo-ocular reflex are compensated for, which is not the case for most other fixation detection algorithms. Read more about that in the [Pupil Labs fixation detector whitepaper](https://docs.google.com/document/d/1dTL1VS83F-W1AZfbG-EogYwq2PFk463HqwGgshK3yJE/export?format=pdf)
 
 ## Blinks
 During blinks the eye is briefly covered by the eye lids, which serves the purpose of spreading tears across the cornea. The blink rate and blink duration are also correlated with cognitive processes, which makes them interesting physiological signals.


### PR DESCRIPTION
Currently using a link that downloads a pdf version of the article from Google Drive. This allows for easier editing of the document, but we might want to change where we're hosting the pdf.