### PR TITLE
🚑  Hotfix: Update Sidebar.vue to include Neon on phones

### DIFF
--- a/src/.vuepress/theme/components/Sidebar.vue
+++ b/src/.vuepress/theme/components/Sidebar.vue
@@ -36,6 +36,7 @@ export default {
     return {
       docs_menu: [
         { icon: "home", title: "home", link: "/" },
+        { icon: "neon", title: "neon", link: "/neon/" },
         { icon: "invisible", title: "invisible", link: "/invisible/" },
         { icon: "core", title: "core", link: "/core/" },
         { icon: "vr-ar", title: "vr/ar", link: "/vr-ar/" },


### PR DESCRIPTION
Show neon on the sidebar menu when using small screens.