### PR TITLE
Update config.mts to include Cloud Troubleshooting link

### DIFF
--- a/neon/.vitepress/config.mts
+++ b/neon/.vitepress/config.mts
@@ -193,6 +193,7 @@ let theme_config_additions = {
           },
         ],
       },
+      { text: "Troubleshooting", link: "/pupil-cloud/troubleshooting/" },
     ],
     "/neon-player/": [
       {


### PR DESCRIPTION
The troubleshooting link for Pupil Cloud was missing from the sidebar.