### PR TITLE
Mapping Correction seperate in Sidebar 

### DIFF
--- a/neon/.vitepress/config.mts
+++ b/neon/.vitepress/config.mts
@@ -180,10 +180,6 @@ let theme_config_additions = {
             link: "/pupil-cloud/enrichments/marker-mapper/",
           },
           {
-            text: "Mapping Correction",
-            link: "/pupil-cloud/enrichments/mapping-correction/",
-          },
-          {
             text: "Face Mapper",
             link: "/pupil-cloud/enrichments/face-mapper/",
           },
@@ -193,6 +189,7 @@ let theme_config_additions = {
           },
         ],
       },
+      { text: "Mapping Correction", link: "/pupil-cloud/enrichments/mapping-correction/" },
       {
         text: "Visualizations",
         items: [


### PR DESCRIPTION
Mapping Correction was decided to be placed seperate from the enrichments in sidebar to indicate that it is not actually an enrichment, but a fine-tuning tool